### PR TITLE
Only show public URL's for other entities

### DIFF
--- a/start.php
+++ b/start.php
@@ -218,6 +218,7 @@ function auto_sitemap_getOtherEntityUrls( $entities ){
 		}
 		
 		$options['limit'] = $max_urls;
+		$options['wheres'] = array('e.access_id = 2');
 				
 		$entradas = elgg_get_entities($options);
 				


### PR DESCRIPTION
Currently all URL's will be shown for the non default entities. This might provide unwanted information to be leaked (title might contain information that should not be seen by others).